### PR TITLE
Update aws provider to 4.x

### DIFF
--- a/cluster/production-v1/versions.tf
+++ b/cluster/production-v1/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_providers {
-    aws = {
-      version = "~> 3.0"
-    }
-    tls = {
-      version = "~> 3.0"
-    }
+    aws = { version = "~> 4.0" }
+    tls = { version = "~> 3.0" }
   }
 }

--- a/cluster/sandbox-v1/versions.tf
+++ b/cluster/sandbox-v1/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_providers {
-    aws = {
-      version = "~> 3.0"
-    }
-    tls = {
-      version = "~> 3.0"
-    }
+    aws = { version = "~> 4.0" }
+    tls = { version = "~> 3.0" }
   }
 }

--- a/ingress/production/versions.tf
+++ b/ingress/production/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    aws = { version = "~> 3.0" }
+    aws = { version = "~> 4.0" }
   }
 }

--- a/ingress/sandbox/versions.tf
+++ b/ingress/sandbox/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    aws = { version = "~> 3.0" }
+    aws = { version = "~> 4.0" }
   }
 }

--- a/network/production/versions.tf
+++ b/network/production/versions.tf
@@ -1,7 +1,5 @@
 terraform {
   required_providers {
-    aws = {
-      version = "~> 3.0"
-    }
+    aws = { version = "~> 4.0" }
   }
 }

--- a/network/sandbox/versions.tf
+++ b/network/sandbox/versions.tf
@@ -1,7 +1,5 @@
 terraform {
   required_providers {
-    aws = {
-      version = "~> 3.0"
-    }
+    aws = { version = "~> 4.0" }
   }
 }

--- a/platform/production-v1/versions.tf
+++ b/platform/production-v1/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    aws        = { version = "~> 3.0" }
+    aws        = { version = "~> 4.0" }
     helm       = { version = "~> 2.1" }
     kubernetes = { version = "~> 2.2" }
   }

--- a/platform/sandbox-v1/versions.tf
+++ b/platform/sandbox-v1/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    aws        = { version = "~> 3.0" }
+    aws        = { version = "~> 4.0" }
     helm       = { version = "~> 2.1" }
     kubernetes = { version = "~> 2.2" }
   }

--- a/templates/versions.tf
+++ b/templates/versions.tf
@@ -1,7 +1,5 @@
 terraform {
   required_providers {
-    aws = {
-      version = "~> 3.0"
-    }
+    aws = { version = "~> 4.0" }
   }
 }


### PR DESCRIPTION
We have updated the Flightdeck modules to use the 4.x version of the aws provider, so the root modules must also use this version.
